### PR TITLE
Add Commands to install libwnck-3-0 on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ List the windows which title or application name match the query term.
 ## Requirements
 
 * wnck3 (libwnck-3-0 on Ubuntu, libwnck3 on Arch)
+
+To install libwnck-3-0 on **Ubuntu** ->
+```
+$ sudo apt-get update -y
+$ sudo apt-get install -y libwnck-3-0
+```


### PR DESCRIPTION
## Problem
Instructions to install `libwnck-3-0` on Ubuntu were not there.

## Solution
I have written the instructions to install the `libwnck-3-0` on Ubuntu for the convenience of other people who use this extension.